### PR TITLE
add fleet analytics hook

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@ RUN install_packages \
     kmod \
     libiio0 \
     libiio-utils \
-    python3-libiio
+    python3-libiio 
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
just an example of how to extend the sensor to push the data to fleet analytics sink.
assumes that the fleet analytics transport service will run on the same device (port 5000)