### PR TITLE
Added partial support for SGP30

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This command searches the running kernel for all the drivers it includes and pri
 | ADS1015 | Texas Instruments ADS1015 ADC | ti-ads1015 | 0x48 - 0x4B | Yes, NOT working |
 | TSL4531 | TAOS TSL4531 ambient light sensors | tsl4531 | 0x29 | Not tested |
 | VEML6070 | VEML6070 UV A light sensor | veml6070 | 0x38, 0x39 | Yes, works |
+| SGP30 | Sensirion SGP30 Air Quality Sensor | sgp30 | 0x58 | Yes, works partially (no H2 & Ethanol reading) | 
 
 By default, the block searches for sensors on SMBus number 1 (/dev/i2c-1) however you can set the bus number (an integer value) using the `BUS_NUMBER` service variable.
 

--- a/balena.yml
+++ b/balena.yml
@@ -1,7 +1,7 @@
 name: sensor
 description: >-
   detect and publish data from supported i2c sensors on the Raspberry Pi via http and/or mqtt
-version: 1.0.0
+version: 1.0.1
 type: sw.application
 assets:
   repository:

--- a/idetect.py
+++ b/idetect.py
@@ -26,6 +26,7 @@ devices = {
 73:     "ti-ads1015",
 74:     "ti-ads1015",
 75:     "ti-ads1015",
+88:     "sgp30",
 104:    "mcp3422",
 105:    "mcp3422",
 106:    "mcp3422",
@@ -48,6 +49,7 @@ del_drivers = {
 "htu21": "htu21",
 "mcp320x": "mcp320x",
 "mcp3422": "mcp3422",
+"sgp30": "sgp30",
 "ti-ads1015": "ti-ads1015",
 "tsl4531": "tsl4531",
 "veml6070": "veml6070"

--- a/transformers.py
+++ b/transformers.py
@@ -65,4 +65,17 @@ def device_transform(device_name, fields):
                 new_fields[field] = x/1000
                 new_fields["humidity"] = new_fields.pop("humidityrelative")
 
+    elif device_name == "sgp30":
+        print("Transforming {0} value(s)...".format(device_name))
+        for field in fields:
+            if field == "concentration_co2":
+                x = fields[field]
+                new_fields[field] = x*1000000
+            elif field == "concentration_voc":
+                x = fields[field]
+                new_fields[field] = x*1000000000
+            elif ((field == "concentration_ethanol") or (field == "concentration_h2")):
+                # both values not correct as driver does not calibrate them, so remove them
+                new_fields.pop(field)
+
     return new_fields


### PR DESCRIPTION
C02 (ppm) and VOC (ppb) are supported, Ethanol and H2 are removed because not supported in the outdated SGP30 driver in the iio.